### PR TITLE
Add dual Claude Code & OpenAI Codex backend support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,13 +45,13 @@ The relay uses a `Provider` interface (`server/src/provider.ts`) to abstract bac
 | Provider | File | Backend Protocol | Credentials |
 |---|---|---|---|
 | **Anthropic** | `server/src/anthropic.ts` | WebSocket subscription + REST | `ANTHROPIC_TOKEN` (or macOS Keychain) |
-| **Codex** | `server/src/codex.ts` | JSON-RPC 2.0 over WebSocket | `CODEX_APP_SERVER_URL` |
+| **Codex** | `server/src/codex.ts` | JSON-RPC 2.0 over WebSocket | `CODEX_APP_SERVER_URL` (+ `WATCHCODE_SECRET` when using an authenticated proxy/tunnel) |
 
 Providers are initialized at startup based on available credentials. When both are configured, sessions from both appear in a unified list with a `provider` field.
 
 ### Authentication
 
-The relay server holds backend credentials server-side (Anthropic OAuth token via `ANTHROPIC_TOKEN` env var or macOS Keychain; Codex via `CODEX_APP_SERVER_URL` pointing to an already-running app-server). Clients authenticate to the relay using a shared secret (`x-watchcode-secret` header).
+The relay server holds backend credentials server-side (Anthropic OAuth token via `ANTHROPIC_TOKEN` env var or macOS Keychain; Codex via `CODEX_APP_SERVER_URL` pointing to an already-running app-server or authenticated proxy). Clients authenticate to the relay using a shared secret (`x-watchcode-secret` header). The relay also forwards that same header on Codex WebSocket connections when `WATCHCODE_SECRET` is configured.
 
 ### API Surface
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,20 +2,24 @@
 
 ## Overview
 
-WatchCode connects an Apple Watch to a running Claude Code terminal session via the Remote Control protocol. Users speak into their Watch to send prompts and see live session activity — using their existing Claude subscription with zero additional API cost.
+WatchCode connects an Apple Watch to running Claude Code and/or OpenAI Codex terminal sessions. Users speak into their Watch to send prompts and see live session activity — using their existing subscriptions with zero additional API cost.
 
-The system has two main components: a **Node.js relay server** that bridges Anthropic's WebSocket protocol to HTTP/SSE for watchOS compatibility, and a **SwiftUI Watch app** that handles voice input and event display. A **React web client** is included for testing and monitoring.
+The system has two main components: a **Node.js relay server** that bridges backend WebSocket protocols (Anthropic Remote Control and Codex App Server) to HTTP/SSE for watchOS compatibility, and a **SwiftUI Watch app** that handles voice input and event display. A **React web client** is included for testing and monitoring.
 
 ---
 
 ## System Architecture
 
 ```
-┌──────────────────┐          ┌──────────────────────┐          ┌────────────────────┐          ┌───────────────┐
-│   Claude Code    │───WS───> │   api.anthropic.com  │ <───WS───│   Relay Server     │ <──HTTP──│  Apple Watch  │
-│   (user terminal)│          │   (Anthropic relay)   │          │   (Node.js, hosted)│───SSE──> │  (SwiftUI)    │
-│                  │ <──WS─── │                       │ ───WS──> │                    │          │               │
-└──────────────────┘          └──────────────────────┘          └────────────────────┘          └───────────────┘
+┌──────────────────┐          ┌──────────────────────┐
+│   Claude Code    │───WS───> │   api.anthropic.com  │ <──WS──┐
+│   (user terminal)│ <──WS─── │   (Anthropic relay)  │ ──WS──>│
+└──────────────────┘          └──────────────────────┘         │  ┌────────────────────┐  ┌───────────────┐
+                                                               ├──│   Relay Server     │──│  Apple Watch  │
+┌──────────────────┐          ┌──────────────────────┐         │  │   (Node.js, hosted)│  │  (SwiftUI)    │
+│      Codex       │───WS───> │   Codex App Server   │ <──WS──┘  └────────────────────┘  └───────────────┘
+│   (user terminal)│ <──WS─── │   (local/remote)     │ ──WS──>        HTTP/SSE
+└──────────────────┘          └──────────────────────┘
 ```
 
 ---
@@ -24,27 +28,38 @@ The system has two main components: a **Node.js relay server** that bridges Anth
 
 ### Purpose
 
-Protocol bridge between Anthropic's WebSocket-based Remote Control API and the Apple Watch's HTTP/SSE capabilities. watchOS restricts WebSocket APIs to audio streaming apps, so the relay translates to standard HTTP which watchOS fully supports.
+Protocol bridge between backend WebSocket APIs and the Apple Watch's HTTP/SSE capabilities. watchOS restricts WebSocket APIs to audio streaming apps, so the relay translates to standard HTTP which watchOS fully supports. The relay supports multiple backends simultaneously through a **Provider** abstraction.
 
 ### Tech Stack
 
 - **Runtime:** Node.js
 - **Framework:** Express 5
-- **WebSocket client:** `ws` package (connecting to Anthropic)
+- **WebSocket client:** `ws` package (connecting to Anthropic and Codex app-server)
 - **SSE:** Native HTTP response streaming
 - **Hosting:** Any Node.js host (Railway, Fly.io, Render, VPS)
 
+### Provider Architecture
+
+The relay uses a `Provider` interface (`server/src/provider.ts`) to abstract backend differences. Each provider implements session listing, connection, messaging, control, and event transformation.
+
+| Provider | File | Backend Protocol | Credentials |
+|---|---|---|---|
+| **Anthropic** | `server/src/anthropic.ts` | WebSocket subscription + REST | `ANTHROPIC_TOKEN` (or macOS Keychain) |
+| **Codex** | `server/src/codex.ts` | JSON-RPC 2.0 over WebSocket | `CODEX_APP_SERVER_URL` |
+
+Providers are initialized at startup based on available credentials. When both are configured, sessions from both appear in a unified list with a `provider` field.
+
 ### Authentication
 
-The relay server holds the Anthropic OAuth token server-side (via `ANTHROPIC_TOKEN` env var, or falls back to reading the macOS Keychain for local development). Clients authenticate to the relay using a shared secret (`x-watchcode-secret` header).
+The relay server holds backend credentials server-side (Anthropic OAuth token via `ANTHROPIC_TOKEN` env var or macOS Keychain; Codex via `CODEX_APP_SERVER_URL` pointing to an already-running app-server). Clients authenticate to the relay using a shared secret (`x-watchcode-secret` header).
 
 ### API Surface
 
-**`GET /api/sessions`** — List available Remote Control sessions from Anthropic.
+**`GET /api/sessions`** — List available sessions from all configured providers.
 
-**`POST /api/connect`** — Connect to a session. Opens a WebSocket to Anthropic, fetches event history via REST, and returns a `connectionId`.
-- Request body: `{ "sessionId": "<id>" }`
-- Response: `{ "connectionId": "<uuid>", "status": "connected" }`
+**`POST /api/connect`** — Connect to a session. Routes to the appropriate provider, opens a backend connection, fetches event history, and returns a `connectionId`.
+- Request body: `{ "sessionId": "<id>", "provider": "anthropic" | "codex" }`
+- Response: `{ "connectionId": "<uuid>", "status": "connected", "provider": "anthropic" | "codex" }`
 
 **`GET /api/sessions/:sessionId/events`** — SSE stream of session events. Flushes buffered history, then streams live events.
 - Query params: `connectionId=<uuid>`
@@ -63,32 +78,34 @@ The relay server holds the Anthropic OAuth token server-side (via `ANTHROPIC_TOK
 ### Internal Architecture
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│ Relay Server                                            │
-│                                                         │
-│  ┌──────────────┐    ┌──────────────┐    ┌───────────┐  │
-│  │ HTTP Router   │───>│ Connection   │───>│ WS Client │──── wss://api.anthropic.com
-│  │ (Express)     │    │ Store        │    │           │  │
-│  │               │<───│ (in-memory)  │<───│           │<─── (session events)
-│  └──────┬───────┘    └──────────────┘    └───────────┘  │
-│         │                                                │
-│  ┌──────▼───────┐    ┌──────────────┐                   │
-│  │ SSE Writer    │───>│ Event        │                   │
-│  │               │    │ Transformer  │                   │
-│  └──────────────┘    └──────────────┘                   │
-│                                                         │
-└─────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│ Relay Server                                                         │
+│                                                                      │
+│  ┌──────────────┐    ┌──────────────┐    ┌────────────────────────┐  │
+│  │ HTTP Router   │───>│ Connection   │───>│ Provider Registry      │  │
+│  │ (Express)     │    │ Store        │    │                        │  │
+│  │               │<───│ (in-memory)  │    │  ┌──────────────────┐  │  │
+│  └──────┬───────┘    └──────────────┘    │  │ AnthropicProvider │──── wss://api.anthropic.com
+│         │                                │  └──────────────────┘  │  │
+│  ┌──────▼───────┐                        │  ┌──────────────────┐  │  │
+│  │ SSE Writer    │                        │  │ CodexProvider    │──── ws://app-server
+│  │               │                        │  └──────────────────┘  │  │
+│  └──────────────┘                        └────────────────────────┘  │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
-**Connection Store:** In-memory map of `connectionId → { ws, sessionId, sseClients[], eventBuffer[] }`. When connecting, any existing connection to the same session is closed first to get a fresh history replay.
+**Provider Registry:** Maps provider names to `Provider` instances. Each provider encapsulates its own credentials, connection logic, and event transformation. Providers are initialized at startup based on environment variables.
 
-**Event Transformer:** Converts raw Anthropic session events into simplified payloads for the Watch. Strips markdown, summarizes verbose tool outputs (file contents, bash output), and provides human-readable tool input descriptions.
+**Connection Store:** In-memory map of `connectionId → { provider, providerConn, sessionId, sseClients[], eventBuffer[] }`. When connecting, any existing connection to the same session is closed first to get a fresh history replay.
 
-**Event Buffer:** Events arriving before an SSE client connects are buffered. On first SSE connection, historical events (fetched via REST) and buffered live events are flushed immediately.
+**Event Transformer:** Each provider converts its raw backend events into simplified `WatchEvent` payloads. Strips markdown, summarizes verbose tool outputs, and provides human-readable tool input descriptions. The Anthropic provider handles Claude Code tools (Bash, Read, Write, etc.); the Codex provider handles Codex tools (shell, read_file, apply_diff, etc.).
+
+**Event Buffer:** Events arriving before an SSE client connects are buffered. On first SSE connection, historical events and buffered live events are flushed immediately.
 
 ### Security
 
-- **Server-side credentials.** The OAuth token is stored on the relay, not sent by clients.
+- **Server-side credentials.** Backend tokens and URLs are stored on the relay, not sent by clients.
 - **Shared secret auth.** All `/api` endpoints require the `x-watchcode-secret` header when configured.
 - **TLS required in production.** Deploy behind HTTPS to protect the shared secret in transit.
 - **Connection scoping.** Each `connectionId` is a UUID tied to a specific session.

--- a/README.md
+++ b/README.md
@@ -5,28 +5,33 @@
 <h1 align="center">WatchCode</h1>
 
 <p align="center">
-  Control Claude Code from your Apple Watch.<br>
+  Control Claude Code and OpenAI Codex from your Apple Watch.<br>
   Speak prompts, see live activity, interrupt tasks — so you can touch grass while shipping code.
 </p>
 
 <p align="center">
-  Uses your existing Claude subscription with zero additional API cost.
+  Uses your existing subscriptions with zero additional API cost.
 </p>
 
 ---
 
 ```
-┌──────────────┐         ┌─────────────┐         ┌──────────────┐         ┌─────────────┐
-│  Claude Code │──WS───> │  Anthropic   │ <──WS── │ Relay Server │ <─HTTP─ │ Apple Watch │
-│  (terminal)  │ <──WS── │  (relay API) │ ──WS──> │  (Node.js)   │ ──SSE─> │  (SwiftUI)  │
-└──────────────┘         └─────────────┘         └──────────────┘         └─────────────┘
+┌──────────────┐         ┌─────────────┐
+│  Claude Code │──WS───> │  Anthropic   │ <──WS──┐
+│  (terminal)  │ <──WS── │  (relay API) │ ──WS──>│
+└──────────────┘         └─────────────┘         │    ┌──────────────┐         ┌─────────────┐
+                                                 ├───>│ Relay Server │ <─HTTP─ │ Apple Watch │
+┌──────────────┐         ┌─────────────┐         │    │  (Node.js)   │ ──SSE─> │  (SwiftUI)  │
+│    Codex     │──WS───> │  Codex App  │ <──WS──┘    └──────────────┘         └─────────────┘
+│  (terminal)  │ <──WS── │   Server    │ ──WS──>
+└──────────────┘         └─────────────┘
 ```
 
-> **Why a relay?** watchOS restricts WebSocket APIs to audio streaming apps only. The relay bridges Anthropic's WebSocket protocol to standard HTTP/SSE, which watchOS fully supports.
+> **Why a relay?** watchOS restricts WebSocket APIs to audio streaming apps only. The relay bridges backend WebSocket protocols to standard HTTP/SSE, which watchOS fully supports.
 
 ## How It Works
 
-WatchCode bridges Claude Code's [Remote Control](https://docs.anthropic.com/en/docs/claude-code/remote-control) WebSocket protocol to HTTP/SSE so watchOS can consume it. The relay server connects to Anthropic's API on behalf of the Watch, transforms raw session events into a compact format, and streams them over SSE.
+WatchCode bridges Claude Code's [Remote Control](https://docs.anthropic.com/en/docs/claude-code/remote-control) and OpenAI Codex's [App Server](https://developers.openai.com/codex/app-server) protocols to HTTP/SSE so watchOS can consume them. The relay server connects to one or both backends, transforms raw session events into a compact format, and streams them over SSE. Sessions from both providers appear in a unified list.
 
 **The Watch app provides:**
 - Voice dictation to send prompts
@@ -47,7 +52,7 @@ WatchCode bridges Claude Code's [Remote Control](https://docs.anthropic.com/en/d
 ### Prerequisites
 
 - Node.js 20+
-- An active [Claude](https://claude.ai) subscription with Claude Code
+- An active [Claude](https://claude.ai) subscription with Claude Code and/or [OpenAI Codex](https://openai.com/index/introducing-codex/) CLI
 - Xcode 26+ (for the Watch app)
 - An Apple Watch running watchOS 26+
 
@@ -67,12 +72,18 @@ ANTHROPIC_TOKEN=your_token_here
 # Optional: your Anthropic org UUID (run: claude auth status)
 ANTHROPIC_ORG_UUID=
 
+# Codex app-server WebSocket URL (run: codex app-server --listen ws://127.0.0.1:4500)
+# Leave empty to disable Codex provider
+CODEX_APP_SERVER_URL=ws://127.0.0.1:4500
+
 # Shared secret for Watch app auth (generate: openssl rand -hex 32)
 WATCHCODE_SECRET=
 
 # Server port
 PORT=3847
 ```
+
+> **Note:** At least one provider must be configured. You can enable just Claude Code, just Codex, or both.
 
 ```bash
 # Development (with hot reload)
@@ -103,8 +114,9 @@ The relay server can be deployed to any Node.js host (Railway, Fly.io, Render, e
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `ANTHROPIC_TOKEN` | Yes | Your Anthropic OAuth token |
+| `ANTHROPIC_TOKEN` | For Claude | Your Anthropic OAuth token |
 | `ANTHROPIC_ORG_UUID` | No | Anthropic organization UUID |
+| `CODEX_APP_SERVER_URL` | For Codex | Codex app-server WebSocket URL |
 | `WATCHCODE_SECRET` | Recommended | Shared secret for request authentication |
 | `PORT` | No | Server port (default: 3847) |
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ ANTHROPIC_TOKEN=your_token_here
 ANTHROPIC_ORG_UUID=
 
 # Codex app-server WebSocket URL (run: codex app-server --listen ws://127.0.0.1:4500)
+# Can also be a remote authenticated proxy/tunnel URL that forwards to a local Codex instance
 # Leave empty to disable Codex provider
 CODEX_APP_SERVER_URL=ws://127.0.0.1:4500
 
-# Shared secret for Watch app auth (generate: openssl rand -hex 32)
+# Shared secret for Watch app auth and Codex upstream WebSocket auth
+# when connecting to Codex through an authenticated proxy/tunnel
 WATCHCODE_SECRET=
 
 # Server port
@@ -116,8 +118,8 @@ The relay server can be deployed to any Node.js host (Railway, Fly.io, Render, e
 |----------|----------|-------------|
 | `ANTHROPIC_TOKEN` | For Claude | Your Anthropic OAuth token |
 | `ANTHROPIC_ORG_UUID` | No | Anthropic organization UUID |
-| `CODEX_APP_SERVER_URL` | For Codex | Codex app-server WebSocket URL |
-| `WATCHCODE_SECRET` | Recommended | Shared secret for request authentication |
+| `CODEX_APP_SERVER_URL` | For Codex | Codex app-server WebSocket URL or authenticated proxy/tunnel URL |
+| `WATCHCODE_SECRET` | Recommended | Shared secret for relay API auth and Codex upstream WebSocket auth |
 | `PORT` | No | Server port (default: 3847) |
 
 When no `WATCHCODE_SECRET` is set, the relay runs in open mode (suitable for local development only).
@@ -140,6 +142,7 @@ All endpoints require the `x-watchcode-secret` header when `WATCHCODE_SECRET` is
 
 - **No credential storage.** OAuth tokens are passed through and never written to disk by the relay.
 - **Shared secret auth.** The `WATCHCODE_SECRET` prevents unauthorized access to your relay.
+- **Codex upstream auth.** When `CODEX_APP_SERVER_URL` points to an authenticated proxy/tunnel, the relay also sends `x-watchcode-secret: <WATCHCODE_SECRET>` on the upstream Codex WebSocket connection.
 - **TLS required in production.** Deploy behind HTTPS to protect tokens in transit.
 
 ## Architecture

--- a/WatchCode/WatchCode Watch App/Models/SessionInfo.swift
+++ b/WatchCode/WatchCode Watch App/Models/SessionInfo.swift
@@ -8,4 +8,5 @@ struct SessionInfo: Codable, Identifiable {
     let environmentId: String
     let createdAt: String
     let updatedAt: String
+    let provider: String?
 }

--- a/WatchCode/WatchCode Watch App/Services/RelayClient.swift
+++ b/WatchCode/WatchCode Watch App/Services/RelayClient.swift
@@ -23,6 +23,7 @@ class RelayClient {
 
     private var connectionId: String?
     private var currentSessionId: String?
+    var currentProvider: String?
     private var streamTask: Task<Void, Never>?
     private var reconnectAttempts = 0
     private let maxReconnectAttempts = 3
@@ -59,9 +60,10 @@ class RelayClient {
 
     // MARK: - Connection
 
-    func connect(sessionId: String) async {
+    func connect(sessionId: String, provider: String? = nil) async {
         connectionState = .connecting
         currentSessionId = sessionId
+        currentProvider = provider
         events = []
         reconnectAttempts = 0
 
@@ -74,7 +76,7 @@ class RelayClient {
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             applyAuth(&request)
-            request.httpBody = try JSONEncoder().encode(ConnectRequest(sessionId: sessionId))
+            request.httpBody = try JSONEncoder().encode(ConnectRequest(sessionId: sessionId, provider: currentProvider))
 
             let (data, _) = try await URLSession.shared.data(for: request)
             let response = try JSONDecoder().decode(ConnectResponse.self, from: data)
@@ -194,6 +196,7 @@ private struct SessionsResponse: Codable {
 
 private struct ConnectRequest: Codable {
     let sessionId: String
+    let provider: String?
 }
 
 private struct ConnectResponse: Codable {

--- a/WatchCode/WatchCode Watch App/Views/SessionListView.swift
+++ b/WatchCode/WatchCode Watch App/Views/SessionListView.swift
@@ -26,7 +26,7 @@ struct SessionListView: View {
                     Text("No Sessions")
                         .font(.caption)
                         .fontWeight(.medium)
-                    Text("Run Claude Code with the relay server to see sessions here.")
+                    Text("Run a coding agent with the relay server to see sessions here.")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
@@ -38,7 +38,7 @@ struct SessionListView: View {
                 if !liveSessions.isEmpty {
                     Section {
                         ForEach(liveSessions) { session in
-                            NavigationLink(destination: SessionView(sessionId: session.id)) {
+                            NavigationLink(destination: SessionView(sessionId: session.id, provider: session.provider)) {
                                 SessionRow(session: session)
                             }
                         }
@@ -53,7 +53,7 @@ struct SessionListView: View {
                 if !archivedSessions.isEmpty {
                     Section {
                         ForEach(archivedSessions.prefix(10)) { session in
-                            NavigationLink(destination: SessionView(sessionId: session.id)) {
+                            NavigationLink(destination: SessionView(sessionId: session.id, provider: session.provider)) {
                                 SessionRow(session: session)
                             }
                         }
@@ -112,6 +112,12 @@ struct SessionRow: View {
 
             HStack(spacing: 6) {
                 StatusBadge(status: session.status)
+
+                if let provider = session.provider {
+                    Text(provider == "codex" ? "CODEX" : "CLAUDE")
+                        .font(.system(size: 7, weight: .bold, design: .monospaced))
+                        .foregroundStyle(provider == "codex" ? .green : .orange)
+                }
 
                 Text(session.model)
                     .font(.system(size: 9))

--- a/WatchCode/WatchCode Watch App/Views/SessionView.swift
+++ b/WatchCode/WatchCode Watch App/Views/SessionView.swift
@@ -5,6 +5,7 @@ struct SessionView: View {
     @Environment(RelayClient.self) private var client
     @Environment(\.dismiss) private var dismiss
     let sessionId: String
+    let provider: String?
     @State private var messageText = ""
     @State private var showingInput = false
 
@@ -55,7 +56,7 @@ struct SessionView: View {
             messageInputSheet
         }
         .task {
-            await client.connect(sessionId: sessionId)
+            await client.connect(sessionId: sessionId, provider: provider)
         }
         .onDisappear {
             Task { await client.disconnect() }
@@ -197,7 +198,7 @@ struct SessionView: View {
                         if let toolUse = item.toolUse, let toolResult = item.toolResult {
                             ToolEventRow(toolUse: toolUse, toolResult: toolResult)
                         } else if let event = item.event {
-                            EventRow(event: event)
+                            EventRow(event: event, provider: provider)
                         }
                     }
                     Color.clear.frame(height: 1).id("bottom")
@@ -335,10 +336,18 @@ struct ConnectionBanner: View {
 
 struct EventRow: View {
     let event: WatchEvent
+    var provider: String? = nil
     @State private var expanded = false
 
     private var isExpandable: Bool {
         event.type == .assistant && event.content.count > 150
+    }
+
+    private var displayLabel: String {
+        if event.type == .assistant, let provider {
+            return provider == "codex" ? "CODEX" : "CLAUDE"
+        }
+        return event.label
     }
 
     var body: some View {
@@ -359,7 +368,7 @@ struct EventRow: View {
                             .font(.system(size: 7))
                             .foregroundStyle(event.color)
 
-                        Text(event.label)
+                        Text(displayLabel)
                             .font(.system(size: 9, weight: .bold, design: .monospaced))
                             .foregroundStyle(event.color)
 

--- a/WatchCode/WatchCode Watch App/Views/SettingsView.swift
+++ b/WatchCode/WatchCode Watch App/Views/SettingsView.swift
@@ -19,7 +19,7 @@ struct SettingsView: View {
             } header: {
                 Text("Relay Server")
             } footer: {
-                Text("The relay server URL that bridges Claude Code sessions to this app.")
+                Text("The relay server URL that bridges coding agent sessions to this app.")
                     .font(.system(size: 9))
             }
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ export function App() {
   const [state, setState] = useState<ConnectionState>("disconnected");
   const [events, setEvents] = useState<WatchEvent[]>([]);
   const [inputValue, setInputValue] = useState("");
+  const [provider, setProvider] = useState<string | undefined>();
   const eventSourceRef = useRef<EventSource | null>(null);
 
   const addEvent = useCallback((event: WatchEvent) => {
@@ -27,7 +28,7 @@ export function App() {
   }, []);
 
   const connect = useCallback(
-    async (id?: string) => {
+    async (id?: string, prov?: string) => {
       const sid = id || inputValue.trim();
       if (!sid) return;
 
@@ -37,10 +38,11 @@ export function App() {
         : sid;
 
       setSessionId(parsed);
+      setProvider(prov);
       setState("connecting");
 
       try {
-        const connId = await connectSession(parsed);
+        const connId = await connectSession(parsed, prov);
         setConnectionId(connId);
 
         const es = subscribeToEvents(parsed, connId);
@@ -71,6 +73,7 @@ export function App() {
     eventSourceRef.current = null;
     if (connectionId) disconnectSession(connectionId);
     setConnectionId(null);
+    setProvider(undefined);
     setState("disconnected");
   }, [connectionId]);
 
@@ -140,9 +143,9 @@ export function App() {
         )}
       </div>
 
-      {!connected && <SessionList onSelect={(id) => connect(id)} />}
+      {!connected && <SessionList onSelect={(id, prov) => connect(id, prov)} />}
 
-      <EventFeed events={events} />
+      <EventFeed events={events} provider={provider} />
 
       <MessageInput
         disabled={!connected}

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -9,11 +9,11 @@ export async function fetchSessions(): Promise<SessionInfo[]> {
   return data.sessions;
 }
 
-export async function connectSession(sessionId: string): Promise<string> {
+export async function connectSession(sessionId: string, provider?: string): Promise<string> {
   const res = await fetch(`${API_BASE}/api/connect`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ sessionId }),
+    body: JSON.stringify({ sessionId, provider }),
   });
   if (!res.ok) {
     const err = await res.json();

--- a/client/src/components/EventFeed.tsx
+++ b/client/src/components/EventFeed.tsx
@@ -1,32 +1,35 @@
 import { useEffect, useRef } from "react";
 import type { WatchEvent } from "../types";
 
-const LABELS: Record<string, string> = {
-  user: "YOU",
-  assistant: "CLAUDE",
-  tool_use: "TOOL",
-  tool_result: "RESULT",
-  status: "STATUS",
-  error: "ERROR",
-  raw: "RAW",
-};
-
 interface Props {
   events: WatchEvent[];
+  provider?: string;
 }
 
-export function EventFeed({ events }: Props) {
+export function EventFeed({ events, provider }: Props) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [events.length]);
 
+  const assistantLabel = provider === "codex" ? "CODEX" : "CLAUDE";
+
+  const labels: Record<string, string> = {
+    user: "YOU",
+    assistant: assistantLabel,
+    tool_use: "TOOL",
+    tool_result: "RESULT",
+    status: "STATUS",
+    error: "ERROR",
+    raw: "RAW",
+  };
+
   if (events.length === 0) {
     return (
       <div className="empty-state">
         <p>
-          Select a session above or run <code>/rc</code> in Claude Code.
+          Select a session above or start a coding agent.
         </p>
       </div>
     );
@@ -39,7 +42,7 @@ export function EventFeed({ events }: Props) {
           <span className="time">
             {new Date(event.timestamp).toLocaleTimeString()}
           </span>
-          <span className="label">{LABELS[event.type] || event.type}</span>
+          <span className="label">{labels[event.type] || event.type}</span>
           {event.content}
           {event.detail && <span className="detail">{event.detail}</span>}
         </div>

--- a/client/src/components/SessionList.tsx
+++ b/client/src/components/SessionList.tsx
@@ -16,7 +16,7 @@ function badgeClass(status: string): string {
 }
 
 interface Props {
-  onSelect: (sessionId: string) => void;
+  onSelect: (sessionId: string, provider?: string) => void;
 }
 
 export function SessionList({ onSelect }: Props) {
@@ -58,7 +58,7 @@ export function SessionList({ onSelect }: Props) {
         )}
         {!loading && !error && sessions.length === 0 && (
           <div style={{ color: "#555", fontSize: 12, padding: 4 }}>
-            No sessions found. Run /rc in Claude Code.
+            No sessions found. Start a coding agent to see sessions here.
           </div>
         )}
 
@@ -89,16 +89,21 @@ function SessionCard({
   onSelect,
 }: {
   session: SessionInfo;
-  onSelect: (id: string) => void;
+  onSelect: (id: string, provider?: string) => void;
 }) {
   return (
-    <div className="session-card" onClick={() => onSelect(s.id)}>
+    <div className="session-card" onClick={() => onSelect(s.id, s.provider)}>
       <div className="title">
         {s.title}
         <span className={`badge ${badgeClass(s.status)}`}>{s.status.toUpperCase()}</span>
       </div>
       <div className="meta">
         <span className="model">{s.model}</span>
+        {s.provider && (
+          <span className={`provider-badge ${s.provider}`}>
+            {s.provider === "codex" ? "CODEX" : "CLAUDE"}
+          </span>
+        )}
         <br />
         {timeAgo(s.updatedAt)}
       </div>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -146,6 +146,19 @@ button.danger:hover { background: #dc2626; color: #fff; }
 .badge.idle { background: #422006; color: #fbbf24; }
 .badge.archived { background: #1c1c1c; color: #666; }
 
+.provider-badge {
+  display: inline-block;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+.provider-badge.anthropic { background: #3d2a14; color: #d4a574; }
+.provider-badge.codex { background: #0a2e21; color: #10a37f; }
+
 .events {
   flex: 1;
   overflow-y: auto;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -6,6 +6,7 @@ export interface SessionInfo {
   environmentId: string;
   createdAt: string;
   updatedAt: string;
+  provider?: "anthropic" | "codex";
 }
 
 export interface WatchEvent {

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,5 +8,9 @@ ANTHROPIC_ORG_UUID=
 # Shared secret for watch app authentication (generate with: openssl rand -hex 32)
 WATCHCODE_SECRET=
 
+# Codex app-server WebSocket URL (run: codex app-server --listen ws://127.0.0.1:4500)
+# Leave empty to disable Codex provider
+CODEX_APP_SERVER_URL=
+
 # Server port (default: 3847)
 PORT=3847

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,10 +5,12 @@ ANTHROPIC_TOKEN=
 # Run: claude auth status
 ANTHROPIC_ORG_UUID=
 
-# Shared secret for watch app authentication (generate with: openssl rand -hex 32)
+# Shared secret for watch app authentication and Codex upstream WebSocket auth
+# when the relay connects through an authenticated local proxy/tunnel.
 WATCHCODE_SECRET=
 
-# Codex app-server WebSocket URL (run: codex app-server --listen ws://127.0.0.1:4500)
+# Codex app-server WebSocket URL (for local use: run `codex app-server --listen ws://127.0.0.1:4500`)
+# This may also point at a remote authenticated proxy/tunnel that forwards to local Codex.
 # Leave empty to disable Codex provider
 CODEX_APP_SERVER_URL=
 

--- a/server/src/anthropic.ts
+++ b/server/src/anthropic.ts
@@ -1,5 +1,6 @@
 import WebSocket from "ws";
 import type { WatchEvent } from "./types.js";
+import type { Provider, ProviderConnection, SessionInfo, ApiResult } from "./provider.js";
 
 const API_BASE = "https://api.anthropic.com";
 const HEADERS = {
@@ -7,211 +8,208 @@ const HEADERS = {
   "anthropic-beta": "ccr-byoc-2025-07-29",
 };
 
-export interface SessionInfo {
-  id: string;
-  title: string;
-  status: string;
-  model: string;
-  environmentId: string;
-  createdAt: string;
-  updatedAt: string;
+// ─── Provider Connection wrapper ─────────────────────────────────────
+
+class AnthropicConnection implements ProviderConnection {
+  constructor(public handle: WebSocket) {}
+  get readyState(): number {
+    return this.handle.readyState;
+  }
 }
 
-export async function listSessions(
-  token: string,
-  orgUuid: string
-): Promise<SessionInfo[]> {
-  const params = new URLSearchParams();
-  if (orgUuid) params.set("organization_uuid", orgUuid);
+// ─── Provider implementation ─────────────────────────────────────────
 
-  const url = `${API_BASE}/v1/sessions${params.toString() ? `?${params}` : ""}`;
-  const res = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      ...HEADERS,
-      ...(orgUuid ? { "x-organization-uuid": orgUuid } : {}),
-    },
-  });
+export class AnthropicProvider implements Provider {
+  readonly name = "anthropic" as const;
+  private token: string;
+  private orgUuid: string;
 
-  if (!res.ok) {
-    throw new Error(`Failed to list sessions: ${res.status}`);
+  constructor(token: string, orgUuid: string) {
+    this.token = token;
+    this.orgUuid = orgUuid;
   }
 
-  const data = await res.json();
-  const sessions: SessionInfo[] = (data.data || []).map((s: any) => ({
-    id: s.id,
-    title: s.title || "Untitled",
-    status: s.session_status,
-    model: s.session_context?.model || "unknown",
-    environmentId: s.environment_id || "",
-    createdAt: s.created_at,
-    updatedAt: s.updated_at,
-  }));
-
-  // Sort: running first, then idle, then archived. Within each group, most recent first.
-  const priority: Record<string, number> = { running: 0, active: 0, idle: 1, archived: 2 };
-  sessions.sort((a, b) => {
-    const pa = priority[a.status] ?? 2;
-    const pb = priority[b.status] ?? 2;
-    if (pa !== pb) return pa - pb;
-    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-  });
-
-  return sessions;
-}
-
-export function connectToSession(
-  sessionId: string,
-  token: string,
-  orgUuid: string,
-  onEvent: (event: WatchEvent) => void,
-  onClose: () => void
-): WebSocket {
-  const params = orgUuid ? `?organization_uuid=${orgUuid}` : "";
-  const url = `wss://api.anthropic.com/v1/sessions/ws/${sessionId}/subscribe${params}`;
-
-  const ws = new WebSocket(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
+  private authHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
       ...HEADERS,
-    },
-  });
+      ...(this.orgUuid ? { "x-organization-uuid": this.orgUuid } : {}),
+    };
+  }
 
-  ws.on("open", () => {
-    onEvent({
-      type: "status",
-      content: "Connected to Remote Control session",
-      timestamp: new Date().toISOString(),
+  async listSessions(): Promise<SessionInfo[]> {
+    const params = new URLSearchParams();
+    if (this.orgUuid) params.set("organization_uuid", this.orgUuid);
+
+    const url = `${API_BASE}/v1/sessions${params.toString() ? `?${params}` : ""}`;
+    const res = await fetch(url, { headers: this.authHeaders() });
+
+    if (!res.ok) {
+      throw new Error(`Failed to list sessions: ${res.status}`);
+    }
+
+    const data = await res.json();
+    const sessions: SessionInfo[] = (data.data || []).map((s: any) => ({
+      id: s.id,
+      title: s.title || "Untitled",
+      status: s.session_status,
+      model: s.session_context?.model || "unknown",
+      environmentId: s.environment_id || "",
+      createdAt: s.created_at,
+      updatedAt: s.updated_at,
+      provider: "anthropic" as const,
+    }));
+
+    const priority: Record<string, number> = { running: 0, active: 0, idle: 1, archived: 2 };
+    sessions.sort((a, b) => {
+      const pa = priority[a.status] ?? 2;
+      const pb = priority[b.status] ?? 2;
+      if (pa !== pb) return pa - pb;
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
     });
-  });
 
-  ws.on("message", (data) => {
-    try {
-      const raw = JSON.parse(data.toString());
-      const events = transformEvent(raw);
-      for (const event of events) {
-        onEvent(event);
-      }
-    } catch {
+    return sessions;
+  }
+
+  connectToSession(
+    sessionId: string,
+    onEvent: (event: WatchEvent) => void,
+    onClose: () => void
+  ): ProviderConnection {
+    const params = this.orgUuid ? `?organization_uuid=${this.orgUuid}` : "";
+    const url = `wss://api.anthropic.com/v1/sessions/ws/${sessionId}/subscribe${params}`;
+
+    const ws = new WebSocket(url, {
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        ...HEADERS,
+      },
+    });
+
+    ws.on("open", () => {
       onEvent({
-        type: "raw",
-        content: data.toString().slice(0, 500),
+        type: "status",
+        content: "Connected to Remote Control session",
         timestamp: new Date().toISOString(),
       });
-    }
-  });
-
-  ws.on("error", (err) => {
-    onEvent({
-      type: "error",
-      content: err.message,
-      timestamp: new Date().toISOString(),
     });
-  });
 
-  ws.on("close", (code, reason) => {
-    onEvent({
-      type: "status",
-      content: `Disconnected (code: ${code})`,
-      detail: reason.toString() || undefined,
-      timestamp: new Date().toISOString(),
+    ws.on("message", (data) => {
+      try {
+        const raw = JSON.parse(data.toString());
+        const events = transformEvent(raw);
+        for (const event of events) {
+          onEvent(event);
+        }
+      } catch {
+        onEvent({
+          type: "raw",
+          content: data.toString().slice(0, 500),
+          timestamp: new Date().toISOString(),
+        });
+      }
     });
-    onClose();
-  });
 
-  return ws;
-}
+    ws.on("error", (err) => {
+      onEvent({
+        type: "error",
+        content: err.message,
+        timestamp: new Date().toISOString(),
+      });
+    });
 
-export async function sendMessage(
-  sessionId: string,
-  content: string,
-  token: string,
-  orgUuid: string
-): Promise<{ ok: boolean; status: number; body: string }> {
-  const url = `${API_BASE}/v1/sessions/${sessionId}/events`;
-  const eventId = crypto.randomUUID();
+    ws.on("close", (code, reason) => {
+      onEvent({
+        type: "status",
+        content: `Disconnected (code: ${code})`,
+        detail: reason.toString() || undefined,
+        timestamp: new Date().toISOString(),
+      });
+      onClose();
+    });
 
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      ...HEADERS,
-      ...(orgUuid ? { "x-organization-uuid": orgUuid } : {}),
-    },
-    body: JSON.stringify({
-      events: [
-        {
-          uuid: eventId,
-          session_id: sessionId,
-          type: "user",
-          parent_tool_use_id: null,
-          message: { role: "user", content },
-        },
-      ],
-    }),
-  });
-
-  const body = await res.text();
-  return { ok: res.ok, status: res.status, body };
-}
-
-export async function sendControl(
-  sessionId: string,
-  controlType: string,
-  token: string,
-  orgUuid: string
-): Promise<{ ok: boolean; status: number; body: string }> {
-  const url = `${API_BASE}/v1/sessions/${sessionId}/events`;
-  const eventId = crypto.randomUUID();
-
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      ...HEADERS,
-      ...(orgUuid ? { "x-organization-uuid": orgUuid } : {}),
-    },
-    body: JSON.stringify({
-      events: [
-        {
-          uuid: eventId,
-          session_id: sessionId,
-          type: "control",
-          data: { type: controlType },
-        },
-      ],
-    }),
-  });
-
-  const body = await res.text();
-  return { ok: res.ok, status: res.status, body };
-}
-
-export async function fetchSessionEvents(
-  sessionId: string,
-  token: string,
-  orgUuid: string
-): Promise<WatchEvent[]> {
-  const url = `${API_BASE}/v1/sessions/${sessionId}/events`;
-  const res = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      ...HEADERS,
-      ...(orgUuid ? { "x-organization-uuid": orgUuid } : {}),
-    },
-  });
-
-  if (!res.ok) return [];
-
-  const data = await res.json();
-  const rawEvents = Array.isArray(data) ? data : data.data || [];
-  const events: WatchEvent[] = [];
-  for (const raw of rawEvents) {
-    events.push(...transformEvent(raw));
+    return new AnthropicConnection(ws);
   }
-  return events;
+
+  async sendMessage(
+    sessionId: string,
+    content: string,
+    _conn: ProviderConnection
+  ): Promise<ApiResult> {
+    const url = `${API_BASE}/v1/sessions/${sessionId}/events`;
+    const eventId = crypto.randomUUID();
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        ...this.authHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        events: [
+          {
+            uuid: eventId,
+            session_id: sessionId,
+            type: "user",
+            parent_tool_use_id: null,
+            message: { role: "user", content },
+          },
+        ],
+      }),
+    });
+
+    const body = await res.text();
+    return { ok: res.ok, status: res.status, body };
+  }
+
+  async sendControl(
+    sessionId: string,
+    controlType: string,
+    _conn: ProviderConnection
+  ): Promise<ApiResult> {
+    const url = `${API_BASE}/v1/sessions/${sessionId}/events`;
+    const eventId = crypto.randomUUID();
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        ...this.authHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        events: [
+          {
+            uuid: eventId,
+            session_id: sessionId,
+            type: "control",
+            data: { type: controlType },
+          },
+        ],
+      }),
+    });
+
+    const body = await res.text();
+    return { ok: res.ok, status: res.status, body };
+  }
+
+  async fetchSessionEvents(sessionId: string): Promise<WatchEvent[]> {
+    const url = `${API_BASE}/v1/sessions/${sessionId}/events`;
+    const res = await fetch(url, { headers: this.authHeaders() });
+
+    if (!res.ok) return [];
+
+    const data = await res.json();
+    const rawEvents = Array.isArray(data) ? data : data.data || [];
+    const events: WatchEvent[] = [];
+    for (const raw of rawEvents) {
+      events.push(...transformEvent(raw));
+    }
+    return events;
+  }
+
+  disconnect(conn: ProviderConnection): void {
+    (conn.handle as WebSocket).close();
+  }
 }
 
 // ─── Helpers for watch-friendly summaries ───────────────────────────

--- a/server/src/codex.ts
+++ b/server/src/codex.ts
@@ -404,7 +404,7 @@ export class CodexProvider implements Provider {
         const itemType = item?.type;
         const itemId = item?.id || item?.itemId || "unknown";
 
-        if (itemType === "message" || item?.role === "assistant") {
+        if (itemType === "message" && item?.role === "assistant") {
           // Use accumulated delta buffer if available, otherwise extract from item
           let text = deltaBuffers.get(itemId) || "";
           deltaBuffers.delete(itemId);

--- a/server/src/codex.ts
+++ b/server/src/codex.ts
@@ -1,0 +1,511 @@
+import WebSocket from "ws";
+import type { WatchEvent } from "./types.js";
+import type { Provider, ProviderConnection, SessionInfo, ApiResult } from "./provider.js";
+
+// ─── JSON-RPC 2.0 client ────────────────────────────────────────────
+
+class JsonRpcClient {
+  private ws: WebSocket;
+  private nextId = 1;
+  private pending = new Map<number, { resolve: (value: any) => void; reject: (err: Error) => void }>();
+  private notificationHandler: ((method: string, params: any) => void) | null = null;
+
+  constructor(ws: WebSocket) {
+    this.ws = ws;
+    ws.on("message", (data) => {
+      try {
+        const msg = JSON.parse(data.toString());
+        if ("id" in msg && this.pending.has(msg.id)) {
+          const { resolve, reject } = this.pending.get(msg.id)!;
+          this.pending.delete(msg.id);
+          if (msg.error) {
+            reject(new Error(msg.error.message || JSON.stringify(msg.error)));
+          } else {
+            resolve(msg.result);
+          }
+        } else if ("method" in msg && !("id" in msg)) {
+          // Notification (no id)
+          this.notificationHandler?.(msg.method, msg.params);
+        }
+      } catch {
+        // Ignore unparseable messages
+      }
+    });
+  }
+
+  async call(method: string, params?: any, timeoutMs = 10000): Promise<any> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`JSON-RPC call "${method}" timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.pending.set(id, {
+        resolve: (value: any) => { clearTimeout(timer); resolve(value); },
+        reject: (err: Error) => { clearTimeout(timer); reject(err); },
+      });
+
+      this.ws.send(JSON.stringify({ jsonrpc: "2.0", id, method, params: params ?? {} }));
+    });
+  }
+
+  notify(method: string, params?: any): void {
+    this.ws.send(JSON.stringify({ jsonrpc: "2.0", method, params: params ?? {} }));
+  }
+
+  onNotification(handler: (method: string, params: any) => void): void {
+    this.notificationHandler = handler;
+  }
+}
+
+// ─── Provider Connection wrapper ─────────────────────────────────────
+
+class CodexConnection implements ProviderConnection {
+  constructor(public handle: WebSocket, public rpc: JsonRpcClient) {}
+  get readyState(): number {
+    return this.handle.readyState;
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+async function openAndInit(url: string): Promise<{ ws: WebSocket; rpc: JsonRpcClient }> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error("Codex app-server connection timed out"));
+    }, 10000);
+
+    ws.on("open", async () => {
+      clearTimeout(timeout);
+      const rpc = new JsonRpcClient(ws);
+      try {
+        await rpc.call("initialize", {
+          clientInfo: { name: "WatchCode", title: "WatchCode Relay", version: "1.0.0" },
+          capabilities: {},
+        });
+        rpc.notify("initialized");
+        resolve({ ws, rpc });
+      } catch (err) {
+        ws.close();
+        reject(err);
+      }
+    });
+
+    ws.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/`{3}[\s\S]*?`{3}/g, "[code block]")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1")
+    .replace(/__(.+?)__/g, "$1")
+    .replace(/_(.+?)_/g, "$1")
+    .replace(/~~(.+?)~~/g, "$1")
+    .replace(/`(.+?)`/g, "$1")
+    .replace(/^\s*[-*+]\s+/gm, "- ")
+    .replace(/^\s*\d+\.\s+/gm, "")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function truncate(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  return text.slice(0, limit) + "…";
+}
+
+function summarizeResult(content: string): string {
+  if (!content || content.length === 0) return "Done";
+  if (content.length < 120) return content;
+  const lines = content.split("\n").filter((l) => l.trim().length > 0);
+  if (lines.length > 3) return `${lines.length} lines of output`;
+  return content.slice(0, 120) + "…";
+}
+
+function summarizeCodexToolInput(name: string, args: any): string {
+  if (!args || typeof args !== "object") return "";
+  switch (name) {
+    case "shell":
+    case "bash":
+      return args.command ? `$ ${args.command}`.slice(0, 200) : "";
+    case "write":
+    case "create_file":
+      return args.path || args.file_path || "";
+    case "apply_diff":
+    case "apply_patch":
+      return args.path || args.file_path || "";
+    case "read_file":
+      return args.path || args.file_path || "";
+    case "list_dir":
+      return args.path || ".";
+    default: {
+      const parts: string[] = [];
+      for (const [k, v] of Object.entries(args)) {
+        if (typeof v === "string" && v.length < 150) parts.push(`${k}: ${v}`);
+      }
+      return parts.join(", ").slice(0, 200) || JSON.stringify(args).slice(0, 150);
+    }
+  }
+}
+
+// ─── Provider implementation ─────────────────────────────────────────
+
+export class CodexProvider implements Provider {
+  readonly name = "codex" as const;
+  private appServerUrl: string;
+
+  constructor(appServerUrl: string) {
+    this.appServerUrl = appServerUrl;
+  }
+
+  async listSessions(): Promise<SessionInfo[]> {
+    let ws: WebSocket | null = null;
+    try {
+      const { ws: conn, rpc } = await openAndInit(this.appServerUrl);
+      ws = conn;
+
+      // Fetch both stored threads and loaded (running) threads
+      const [threadList, loadedList] = await Promise.all([
+        rpc.call("thread/list", { limit: 50 }).catch(() => ({ threads: [] })),
+        rpc.call("thread/loaded/list", {}).catch(() => ({ threads: [] })),
+      ]);
+
+      const loadedIds = new Set(
+        (loadedList.threads || []).map((t: any) => t.id || t.threadId)
+      );
+
+      const sessions: SessionInfo[] = (threadList.threads || []).map((t: any) => {
+        const threadId = t.id || t.threadId;
+        const isLoaded = loadedIds.has(threadId);
+        const threadStatus = t.status || "unknown";
+
+        let status: string;
+        if (isLoaded && (threadStatus === "active" || threadStatus === "running")) {
+          status = "running";
+        } else if (isLoaded) {
+          status = "idle";
+        } else {
+          status = "archived";
+        }
+
+        return {
+          id: threadId,
+          title: t.title || t.name || "Untitled Thread",
+          status,
+          model: t.model || t.modelId || "codex",
+          environmentId: t.workingDirectory || "",
+          createdAt: t.createdAt || t.created_at || new Date().toISOString(),
+          updatedAt: t.updatedAt || t.updated_at || t.createdAt || new Date().toISOString(),
+          provider: "codex" as const,
+        };
+      });
+
+      ws.close();
+      return sessions;
+    } catch (err: any) {
+      ws?.close();
+      console.log(`[codex] Failed to list sessions: ${err.message}`);
+      return [];
+    }
+  }
+
+  connectToSession(
+    sessionId: string,
+    onEvent: (event: WatchEvent) => void,
+    onClose: () => void
+  ): ProviderConnection {
+    const ws = new WebSocket(this.appServerUrl);
+    const rpc = new JsonRpcClient(ws);
+
+    // Track streaming deltas per item for accumulation
+    const deltaBuffers = new Map<string, string>();
+
+    rpc.onNotification((method, params) => {
+      const ts = new Date().toISOString();
+      const events = this.transformNotification(method, params, ts, deltaBuffers);
+      for (const event of events) {
+        onEvent(event);
+      }
+    });
+
+    ws.on("open", async () => {
+      try {
+        await rpc.call("initialize", {
+          clientInfo: { name: "WatchCode", title: "WatchCode Relay", version: "1.0.0" },
+          capabilities: {},
+        });
+        rpc.notify("initialized");
+
+        onEvent({
+          type: "status",
+          content: "Connected to Codex session",
+          timestamp: new Date().toISOString(),
+        });
+
+        await rpc.call("thread/resume", { threadId: sessionId });
+      } catch (err: any) {
+        onEvent({
+          type: "error",
+          content: `Codex connection failed: ${err.message}`,
+          timestamp: new Date().toISOString(),
+        });
+      }
+    });
+
+    ws.on("error", (err) => {
+      onEvent({
+        type: "error",
+        content: err.message,
+        timestamp: new Date().toISOString(),
+      });
+    });
+
+    ws.on("close", (code) => {
+      onEvent({
+        type: "status",
+        content: `Disconnected (code: ${code})`,
+        timestamp: new Date().toISOString(),
+      });
+      onClose();
+    });
+
+    return new CodexConnection(ws, rpc);
+  }
+
+  async sendMessage(
+    sessionId: string,
+    content: string,
+    conn: ProviderConnection
+  ): Promise<ApiResult> {
+    const codexConn = conn as CodexConnection;
+    try {
+      await codexConn.rpc.call("turn/start", { threadId: sessionId, prompt: content });
+      return { ok: true, status: 200, body: "" };
+    } catch (err: any) {
+      return { ok: false, status: 500, body: err.message };
+    }
+  }
+
+  async sendControl(
+    sessionId: string,
+    controlType: string,
+    conn: ProviderConnection
+  ): Promise<ApiResult> {
+    const codexConn = conn as CodexConnection;
+    try {
+      if (controlType === "interrupt") {
+        await codexConn.rpc.call("turn/interrupt", { threadId: sessionId });
+      } else {
+        // Pass through other control types
+        await codexConn.rpc.call(controlType, { threadId: sessionId });
+      }
+      return { ok: true, status: 200, body: "" };
+    } catch (err: any) {
+      return { ok: false, status: 500, body: err.message };
+    }
+  }
+
+  async fetchSessionEvents(sessionId: string): Promise<WatchEvent[]> {
+    let ws: WebSocket | null = null;
+    try {
+      const { ws: conn, rpc } = await openAndInit(this.appServerUrl);
+      ws = conn;
+
+      const result = await rpc.call("thread/read", { threadId: sessionId });
+      ws.close();
+
+      const events: WatchEvent[] = [];
+      const items = result?.items || result?.thread?.items || [];
+
+      for (const item of items) {
+        const ts = item.createdAt || item.created_at || new Date().toISOString();
+
+        if (item.type === "message" && item.role === "user") {
+          const text = typeof item.content === "string"
+            ? item.content
+            : item.content?.map?.((c: any) => c.text || "").join("") || "";
+          if (text) {
+            events.push({ type: "user", content: text, timestamp: ts });
+          }
+        } else if (item.type === "message" && item.role === "assistant") {
+          const text = typeof item.content === "string"
+            ? item.content
+            : item.content?.map?.((c: any) => c.text || "").join("") || "";
+          if (text) {
+            events.push({
+              type: "assistant",
+              content: text,
+              summary: truncate(stripMarkdown(text), 300),
+              timestamp: ts,
+            });
+          }
+        } else if (item.type === "function_call") {
+          events.push({
+            type: "tool_use",
+            content: item.name || item.function?.name || "unknown tool",
+            detail: summarizeCodexToolInput(
+              item.name || item.function?.name || "",
+              item.arguments || item.function?.arguments || {}
+            ),
+            timestamp: ts,
+          });
+        } else if (item.type === "function_call_output") {
+          const output = typeof item.output === "string" ? item.output : JSON.stringify(item.output || "");
+          events.push({
+            type: "tool_result",
+            content: output,
+            summary: summarizeResult(output),
+            timestamp: ts,
+          });
+        }
+      }
+
+      return events;
+    } catch (err: any) {
+      ws?.close();
+      console.log(`[codex] Failed to fetch session events: ${err.message}`);
+      return [];
+    }
+  }
+
+  disconnect(conn: ProviderConnection): void {
+    (conn.handle as WebSocket).close();
+  }
+
+  // ─── Event transformation for live notifications ──────────────────
+
+  private transformNotification(
+    method: string,
+    params: any,
+    ts: string,
+    deltaBuffers: Map<string, string>
+  ): WatchEvent[] {
+    switch (method) {
+      case "item/agentMessage/delta": {
+        // Accumulate streaming text deltas — emit on item/completed instead
+        const itemId = params?.itemId || params?.id || "unknown";
+        const delta = params?.delta || params?.text || "";
+        const existing = deltaBuffers.get(itemId) || "";
+        deltaBuffers.set(itemId, existing + delta);
+        return [];
+      }
+
+      case "item/completed": {
+        const item = params?.item || params;
+        const itemType = item?.type;
+        const itemId = item?.id || item?.itemId || "unknown";
+
+        if (itemType === "message" || item?.role === "assistant") {
+          // Use accumulated delta buffer if available, otherwise extract from item
+          let text = deltaBuffers.get(itemId) || "";
+          deltaBuffers.delete(itemId);
+
+          if (!text) {
+            text = typeof item.content === "string"
+              ? item.content
+              : item.content?.map?.((c: any) => c.text || "").join("") || "";
+          }
+
+          if (text) {
+            return [{
+              type: "assistant",
+              content: text,
+              summary: truncate(stripMarkdown(text), 300),
+              timestamp: ts,
+            }];
+          }
+          return [];
+        }
+
+        if (itemType === "function_call") {
+          const name = item.name || item.function?.name || "unknown tool";
+          let args = item.arguments || item.function?.arguments;
+          if (typeof args === "string") {
+            try { args = JSON.parse(args); } catch { /* keep as string */ }
+          }
+          return [{
+            type: "tool_use",
+            content: name,
+            detail: summarizeCodexToolInput(name, args),
+            timestamp: ts,
+          }];
+        }
+
+        if (itemType === "function_call_output") {
+          const output = typeof item.output === "string" ? item.output : JSON.stringify(item.output || "");
+          return [{
+            type: "tool_result",
+            content: output,
+            summary: summarizeResult(output),
+            timestamp: ts,
+          }];
+        }
+
+        return [];
+      }
+
+      case "item/commandExecution/outputDelta": {
+        const output = params?.delta || params?.output || params?.text || "";
+        if (output) {
+          return [{
+            type: "tool_result",
+            content: output,
+            summary: summarizeResult(output),
+            timestamp: ts,
+          }];
+        }
+        return [];
+      }
+
+      case "item/fileChange/outputDelta": {
+        const output = params?.delta || params?.output || params?.text || "";
+        if (output) {
+          return [{
+            type: "tool_result",
+            content: output,
+            summary: summarizeResult(output),
+            timestamp: ts,
+          }];
+        }
+        return [];
+      }
+
+      case "turn/started":
+        return [{ type: "status", content: "Turn started", timestamp: ts }];
+
+      case "turn/completed":
+        return [{ type: "status", content: "Turn completed", timestamp: ts }];
+
+      case "thread/status/changed": {
+        const newStatus = params?.status || params?.newStatus || "unknown";
+        return [{ type: "status", content: `Status: ${newStatus}`, timestamp: ts }];
+      }
+
+      case "item/started":
+        // Suppress noisy item start notifications
+        return [];
+
+      case "turn/diff/updated":
+      case "turn/plan/updated":
+      case "thread/tokenUsage/updated":
+        // Suppress verbose metadata notifications
+        return [];
+
+      default:
+        return [{
+          type: "raw",
+          content: JSON.stringify({ method, params }),
+          timestamp: ts,
+        }];
+    }
+  }
+}

--- a/server/src/codex.ts
+++ b/server/src/codex.ts
@@ -72,7 +72,7 @@ class CodexConnection implements ProviderConnection {
 
 async function openAndInit(url: string): Promise<{ ws: WebSocket; rpc: JsonRpcClient }> {
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(url);
+    const ws = createCodexWebSocket(url);
     const timeout = setTimeout(() => {
       ws.close();
       reject(new Error("Codex app-server connection timed out"));
@@ -98,6 +98,13 @@ async function openAndInit(url: string): Promise<{ ws: WebSocket; rpc: JsonRpcCl
       clearTimeout(timeout);
       reject(err);
     });
+  });
+}
+
+function createCodexWebSocket(url: string): WebSocket {
+  const secret = process.env.WATCHCODE_SECRET || "";
+  return new WebSocket(url, {
+    headers: secret ? { "x-watchcode-secret": secret } : undefined,
   });
 }
 
@@ -223,7 +230,7 @@ export class CodexProvider implements Provider {
     onEvent: (event: WatchEvent) => void,
     onClose: () => void
   ): ProviderConnection {
-    const ws = new WebSocket(this.appServerUrl);
+    const ws = createCodexWebSocket(this.appServerUrl);
     const rpc = new JsonRpcClient(ws);
 
     // Track streaming deltas per item for accumulation

--- a/server/src/provider.ts
+++ b/server/src/provider.ts
@@ -1,0 +1,53 @@
+import type { WatchEvent } from "./types.js";
+
+export type ProviderName = "anthropic" | "codex";
+
+export interface SessionInfo {
+  id: string;
+  title: string;
+  status: string;
+  model: string;
+  environmentId: string;
+  createdAt: string;
+  updatedAt: string;
+  provider: ProviderName;
+}
+
+export interface ProviderConnection {
+  handle: any;
+  get readyState(): number;
+}
+
+export interface ApiResult {
+  ok: boolean;
+  status: number;
+  body: string;
+}
+
+export interface Provider {
+  readonly name: ProviderName;
+
+  listSessions(): Promise<SessionInfo[]>;
+
+  connectToSession(
+    sessionId: string,
+    onEvent: (event: WatchEvent) => void,
+    onClose: () => void
+  ): ProviderConnection;
+
+  sendMessage(
+    sessionId: string,
+    content: string,
+    conn: ProviderConnection
+  ): Promise<ApiResult>;
+
+  sendControl(
+    sessionId: string,
+    controlType: string,
+    conn: ProviderConnection
+  ): Promise<ApiResult>;
+
+  fetchSessionEvents(sessionId: string): Promise<WatchEvent[]>;
+
+  disconnect(conn: ProviderConnection): void;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,8 +1,9 @@
 import express from "express";
 import { execSync } from "child_process";
-import type { Response } from "express";
 import type { Connection } from "./types.js";
-import { connectToSession, sendMessage, sendControl, listSessions, fetchSessionEvents } from "./anthropic.js";
+import type { Provider, ProviderName } from "./provider.js";
+import { AnthropicProvider } from "./anthropic.js";
+import { CodexProvider } from "./codex.js";
 
 const app = express();
 const PORT = parseInt(process.env.PORT || "3847");
@@ -27,16 +28,37 @@ app.use("/api", (req, res, next) => {
 // --- In-memory connection store ---
 const connections = new Map<string, Connection>();
 
-// --- Credentials: env vars (production) or Keychain (local dev) ---
-let localToken: string | null = process.env.ANTHROPIC_TOKEN || null;
-let localOrgUuid: string | null = process.env.ANTHROPIC_ORG_UUID || null;
+// --- Provider registry ---
+const providers = new Map<ProviderName, Provider>();
 
-function loadLocalCredentials() {
-  // If env vars are set, skip Keychain entirely
-  if (localToken) {
+function initProviders() {
+  // Anthropic provider
+  const anthropicToken = loadAnthropicToken();
+  const anthropicOrgUuid = loadAnthropicOrgUuid();
+  if (anthropicToken) {
+    providers.set("anthropic", new AnthropicProvider(anthropicToken, anthropicOrgUuid));
+    console.log("[providers] Anthropic provider initialized");
+  } else {
+    console.log("[providers] Anthropic provider disabled (no token)");
+  }
+
+  // Codex provider
+  const codexUrl = process.env.CODEX_APP_SERVER_URL;
+  if (codexUrl) {
+    providers.set("codex", new CodexProvider(codexUrl));
+    console.log(`[providers] Codex provider initialized (${codexUrl})`);
+  } else {
+    console.log("[providers] Codex provider disabled (CODEX_APP_SERVER_URL not set)");
+  }
+}
+
+// --- Anthropic credential loading ---
+
+function loadAnthropicToken(): string | null {
+  const envToken = process.env.ANTHROPIC_TOKEN;
+  if (envToken) {
     console.log("[auth] Token loaded from ANTHROPIC_TOKEN env var");
-    if (localOrgUuid) console.log(`[auth] Org UUID from env: ${localOrgUuid}`);
-    return;
+    return envToken;
   }
 
   // Fall back to macOS Keychain for local dev
@@ -46,72 +68,87 @@ function loadLocalCredentials() {
       { encoding: "utf-8" }
     ).trim();
     const creds = JSON.parse(raw);
-    localToken = creds.claudeAiOauth?.accessToken || null;
-    if (localToken) console.log("[auth] OAuth token loaded from Keychain");
+    const token = creds.claudeAiOauth?.accessToken || null;
+    if (token) console.log("[auth] OAuth token loaded from Keychain");
+    return token;
   } catch {
-    console.log("[auth] Could not read Keychain — use Authorization header or set ANTHROPIC_TOKEN");
+    console.log("[auth] Could not read Keychain — set ANTHROPIC_TOKEN to enable Anthropic provider");
+    return null;
+  }
+}
+
+function loadAnthropicOrgUuid(): string {
+  const envUuid = process.env.ANTHROPIC_ORG_UUID;
+  if (envUuid) {
+    console.log(`[auth] Org UUID from env: ${envUuid}`);
+    return envUuid;
   }
 
   try {
     const status = JSON.parse(
       execSync("claude auth status 2>/dev/null", { encoding: "utf-8" }).trim()
     );
-    localOrgUuid = status.orgId || null;
-    if (localOrgUuid) console.log(`[auth] Org UUID: ${localOrgUuid}`);
+    const orgId = status.orgId || "";
+    if (orgId) console.log(`[auth] Org UUID: ${orgId}`);
+    return orgId;
   } catch {
-    // Not critical
+    return "";
   }
-}
-
-function getToken(req: express.Request): string | null {
-  const auth = req.headers.authorization;
-  if (auth?.startsWith("Bearer ")) return auth.slice(7);
-  return localToken;
-}
-
-function getOrgUuid(req: express.Request): string {
-  return (req.headers["x-organization-uuid"] as string) || localOrgUuid || "";
 }
 
 // --- Routes ---
 
-// List available sessions
-app.get("/api/sessions", async (req, res) => {
-  const token = getToken(req);
-  const orgUuid = getOrgUuid(req);
-
-  if (!token) {
-    res.status(401).json({ error: "No OAuth token available" });
+// List available sessions (from all providers)
+app.get("/api/sessions", async (_req, res) => {
+  if (providers.size === 0) {
+    res.status(503).json({ error: "No providers configured" });
     return;
   }
 
   try {
-    const sessions = await listSessions(token, orgUuid);
+    const allSessions = await Promise.all(
+      [...providers.values()].map((p) => p.listSessions().catch(() => []))
+    );
+    const sessions = allSessions.flat();
+
+    // Sort: running/active first, then idle, then archived
+    const priority: Record<string, number> = { running: 0, active: 0, idle: 1, archived: 2 };
+    sessions.sort((a, b) => {
+      const pa = priority[a.status] ?? 2;
+      const pb = priority[b.status] ?? 2;
+      if (pa !== pb) return pa - pb;
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    });
+
     res.json({ sessions });
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }
 });
 
-// Connect to a Remote Control session
+// Connect to a session
 app.post("/api/connect", async (req, res) => {
-  const { sessionId } = req.body;
-  const token = getToken(req);
-  const orgUuid = getOrgUuid(req);
+  const { sessionId, provider: providerName } = req.body;
 
   if (!sessionId) {
     res.status(400).json({ error: "sessionId required" });
     return;
   }
-  if (!token) {
-    res.status(401).json({ error: "No OAuth token available" });
+
+  const provider = providerName
+    ? providers.get(providerName)
+    : providers.values().next().value;
+
+  if (!provider) {
+    res.status(400).json({ error: providerName ? `Provider "${providerName}" not available` : "No providers configured" });
     return;
   }
 
   // Close any existing connections to this session so we get a fresh history replay
   for (const [id, existing] of connections) {
     if (existing.sessionId === sessionId) {
-      existing.ws.close();
+      const existingProvider = providers.get(existing.provider);
+      existingProvider?.disconnect(existing.providerConn);
       for (const client of existing.sseClients) client.end();
       connections.delete(id);
       console.log(`[ws] Closed stale connection ${id.slice(0, 8)} for reconnect`);
@@ -123,23 +160,19 @@ app.post("/api/connect", async (req, res) => {
   const conn: Connection = {
     id: connectionId,
     sessionId,
-    ws: null as any,
-    token,
-    orgUuid,
+    provider: provider.name,
+    providerConn: null as any,
     sseClients: new Set(),
     lastEvent: Date.now(),
     eventBuffer: [],
   };
 
-  const ws = connectToSession(
+  const providerConn = provider.connectToSession(
     sessionId,
-    token,
-    orgUuid,
     (event) => {
       conn.lastEvent = Date.now();
       const data = `data: ${JSON.stringify(event)}\n\n`;
       if (conn.sseClients.size === 0) {
-        // Buffer events until first SSE client connects
         conn.eventBuffer.push(data);
       } else {
         for (const client of conn.sseClients) {
@@ -148,7 +181,6 @@ app.post("/api/connect", async (req, res) => {
       }
     },
     () => {
-      // On close, notify SSE clients and clean up
       for (const client of conn.sseClients) {
         client.write(`data: ${JSON.stringify({ type: "status", content: "Session disconnected", timestamp: new Date().toISOString() })}\n\n`);
         client.end();
@@ -158,11 +190,11 @@ app.post("/api/connect", async (req, res) => {
     }
   );
 
-  conn.ws = ws;
+  conn.providerConn = providerConn;
 
-  // Fetch history via REST API and prepend to buffer (before any live WS events)
+  // Fetch history and prepend to buffer (before any live events)
   try {
-    const history = await fetchSessionEvents(sessionId, token, orgUuid);
+    const history = await provider.fetchSessionEvents(sessionId);
     if (history.length > 0) {
       const historyData = history.map((e) => `data: ${JSON.stringify(e)}\n\n`);
       conn.eventBuffer = [...historyData, ...conn.eventBuffer];
@@ -173,9 +205,9 @@ app.post("/api/connect", async (req, res) => {
   }
 
   connections.set(connectionId, conn);
-  console.log(`[ws] Connection ${connectionId.slice(0, 8)} opened for session ${sessionId}`);
+  console.log(`[ws] Connection ${connectionId.slice(0, 8)} opened for session ${sessionId} (${provider.name})`);
 
-  res.json({ connectionId, status: "connected" });
+  res.json({ connectionId, status: "connected", provider: provider.name });
 });
 
 // SSE event stream
@@ -204,7 +236,7 @@ app.get("/api/sessions/:sessionId/events", (req, res) => {
 
   conn.sseClients.add(res);
 
-  // Flush any buffered events (history that arrived before SSE client connected)
+  // Flush any buffered events
   if (conn.eventBuffer.length > 0) {
     for (const data of conn.eventBuffer) {
       res.write(data);
@@ -240,8 +272,14 @@ app.post("/api/sessions/:sessionId/message", async (req, res) => {
     return;
   }
 
+  const provider = providers.get(conn.provider);
+  if (!provider) {
+    res.status(500).json({ error: `Provider "${conn.provider}" not available` });
+    return;
+  }
+
   try {
-    const result = await sendMessage(sessionId, content, conn.token, conn.orgUuid);
+    const result = await provider.sendMessage(sessionId, content, conn.providerConn);
     if (result.ok) {
       res.json({ status: "sent" });
     } else {
@@ -266,8 +304,14 @@ app.post("/api/sessions/:sessionId/control", async (req, res) => {
     return;
   }
 
+  const provider = providers.get(conn.provider);
+  if (!provider) {
+    res.status(500).json({ error: `Provider "${conn.provider}" not available` });
+    return;
+  }
+
   try {
-    const result = await sendControl(sessionId, controlType, conn.token, conn.orgUuid);
+    const result = await provider.sendControl(sessionId, controlType, conn.providerConn);
     if (result.ok) {
       res.json({ status: "sent" });
     } else {
@@ -286,7 +330,8 @@ app.delete("/api/connections/:connectionId", (req, res) => {
     return;
   }
 
-  conn.ws.close();
+  const provider = providers.get(conn.provider);
+  provider?.disconnect(conn.providerConn);
   for (const client of conn.sseClients) client.end();
   connections.delete(req.params.connectionId);
 
@@ -298,15 +343,20 @@ app.get("/api/status", (_req, res) => {
   const active = [...connections.values()].map((c) => ({
     connectionId: c.id,
     sessionId: c.sessionId,
+    provider: c.provider,
     sseClients: c.sseClients.size,
-    wsState: c.ws.readyState,
+    wsState: c.providerConn?.readyState ?? -1,
     lastEvent: new Date(c.lastEvent).toISOString(),
   }));
-  res.json({ connections: active });
+  res.json({
+    providers: [...providers.keys()],
+    connections: active,
+  });
 });
 
 // --- Start ---
-loadLocalCredentials();
+initProviders();
 app.listen(PORT, () => {
-  console.log(`\n[relay] WatchCode relay server running on http://localhost:${PORT}\n`);
+  console.log(`\n[relay] WatchCode relay server running on http://localhost:${PORT}`);
+  console.log(`[relay] Active providers: ${[...providers.keys()].join(", ") || "none"}\n`);
 });

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,12 +1,11 @@
 import type { Response } from "express";
-import type { WebSocket } from "ws";
+import type { ProviderName, ProviderConnection } from "./provider.js";
 
 export interface Connection {
   id: string;
   sessionId: string;
-  ws: WebSocket;
-  token: string;
-  orgUuid: string;
+  provider: ProviderName;
+  providerConn: ProviderConnection;
   sseClients: Set<Response>;
   lastEvent: number;
   eventBuffer: string[];
@@ -27,5 +26,5 @@ export interface SendMessageBody {
 
 export interface ConnectBody {
   sessionId: string;
-  orgUuid?: string;
+  provider?: ProviderName;
 }


### PR DESCRIPTION
Introduce a Provider abstraction so the relay server can connect to both Anthropic's Remote Control protocol and Codex's app-server JSON-RPC API simultaneously. Sessions from both backends appear in a unified list with provider badges in the web client and Watch app.

- New server/src/provider.ts: Provider interface, ProviderConnection, shared types
- New server/src/codex.ts: CodexProvider (JSON-RPC 2.0, thread/list, thread/resume, turn/start, turn/interrupt, event transformation with delta accumulation)
- Refactored server/src/anthropic.ts into AnthropicProvider class
- Updated server.ts with provider registry and multi-provider session merging
- Client and Watch app show provider-aware labels (CLAUDE/CODEX) and badges
- Codex disabled by default; enable via CODEX_APP_SERVER_URL env var