### PR TITLE
Fix auth: OAuth refresh token support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,7 +36,7 @@ Protocol bridge between Anthropic's WebSocket-based Remote Control API and the A
 
 ### Authentication
 
-The relay server holds the Anthropic OAuth token server-side (via `ANTHROPIC_TOKEN` env var, or falls back to reading the macOS Keychain for local development). Clients authenticate to the relay using a shared secret (`x-watchcode-secret` header).
+The relay server manages Anthropic OAuth credentials server-side. In production, set `ANTHROPIC_REFRESH_TOKEN` and the server will automatically refresh access tokens before they expire. Alternatively, `ANTHROPIC_TOKEN` can be set directly but expires in ~10 hours. For local development, the server falls back to reading credentials from the macOS Keychain. Clients authenticate to the relay using a shared secret (`x-watchcode-secret` header or `?secret=` query param for SSE).
 
 ### API Surface
 
@@ -88,7 +88,7 @@ The relay server holds the Anthropic OAuth token server-side (via `ANTHROPIC_TOK
 
 ### Security
 
-- **Server-side credentials.** The OAuth token is stored on the relay, not sent by clients.
+- **Server-side credentials.** OAuth tokens are managed on the relay with automatic refresh, not sent by clients.
 - **Shared secret auth.** All `/api` endpoints require the `x-watchcode-secret` header when configured.
 - **TLS required in production.** Deploy behind HTTPS to protect the shared secret in transit.
 - **Connection scoping.** Each `connectionId` is a UUID tied to a specific session.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,15 @@ cp server/.env.example server/.env
 Edit `server/.env`:
 
 ```env
-# Get your OAuth token by running: claude oauth-token
-ANTHROPIC_TOKEN=your_token_here
+# Anthropic OAuth refresh token (recommended — auto-refreshes the access token)
+# Extract from Keychain:
+#   security find-generic-password -s "Claude Code-credentials" -w \
+#     | python3 -c "import sys,json; print(json.loads(sys.stdin.read())['claudeAiOauth']['refreshToken'])"
+ANTHROPIC_REFRESH_TOKEN=
+
+# Or provide a short-lived access token directly (expires in ~10 hours)
+# Run: claude oauth-token
+ANTHROPIC_TOKEN=
 
 # Optional: your Anthropic org UUID (run: claude auth status)
 ANTHROPIC_ORG_UUID=
@@ -94,6 +101,17 @@ npm run build && npm start
 A browser-based interface to the relay for testing and monitoring.
 
 ```bash
+cp client/.env.example client/.env
+```
+
+Edit `client/.env`:
+
+```env
+# Must match the WATCHCODE_SECRET on the server
+VITE_WATCHCODE_SECRET=your_secret_here
+```
+
+```bash
 npm run dev:client
 ```
 
@@ -103,7 +121,8 @@ The relay server can be deployed to any Node.js host (Railway, Fly.io, Render, e
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `ANTHROPIC_TOKEN` | Yes | Your Anthropic OAuth token |
+| `ANTHROPIC_REFRESH_TOKEN` | Recommended | Long-lived OAuth refresh token (auto-refreshes access tokens) |
+| `ANTHROPIC_TOKEN` | Fallback | Short-lived OAuth access token (expires in ~10 hours) |
 | `ANTHROPIC_ORG_UUID` | No | Anthropic organization UUID |
 | `WATCHCODE_SECRET` | Recommended | Shared secret for request authentication |
 | `PORT` | No | Server port (default: 3847) |
@@ -126,7 +145,8 @@ All endpoints require the `x-watchcode-secret` header when `WATCHCODE_SECRET` is
 
 ## Security
 
-- **No credential storage.** OAuth tokens are passed through and never written to disk by the relay.
+- **Automatic token refresh.** When `ANTHROPIC_REFRESH_TOKEN` is set, the server refreshes access tokens automatically before they expire.
+- **No credential storage.** OAuth tokens are kept in memory and never written to disk by the relay.
 - **Shared secret auth.** The `WATCHCODE_SECRET` prevents unauthorized access to your relay.
 - **TLS required in production.** Deploy behind HTTPS to protect tokens in transit.
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ Edit `server/.env`:
 #     | python3 -c "import sys,json; print(json.loads(sys.stdin.read())['claudeAiOauth']['refreshToken'])"
 ANTHROPIC_REFRESH_TOKEN=
 
-# Or provide a short-lived access token directly (expires in ~10 hours)
-# Run: claude oauth-token
+# Or provide a short-lived access token directly (expires in ~10 hours, not recommended for deployment)
 ANTHROPIC_TOKEN=
 
 # Optional: your Anthropic org UUID (run: claude auth status)

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,2 @@
+# Shared secret for server authentication (must match WATCHCODE_SECRET on the server)
+VITE_WATCHCODE_SECRET=

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,9 +1,15 @@
 import type { SessionInfo } from "./types";
 
-const API_BASE = "http://localhost:3847";
+const API_BASE = 'https://watchcode-production.up.railway.app';
+const SECRET = import.meta.env.VITE_WATCHCODE_SECRET ?? '';
+
+const authHeaders: Record<string, string> = {
+  'Content-Type': 'application/json',
+  ...(SECRET ? { 'x-watchcode-secret': SECRET } : {}),
+};
 
 export async function fetchSessions(): Promise<SessionInfo[]> {
-  const res = await fetch(`${API_BASE}/api/sessions`);
+  const res = await fetch(`${API_BASE}/api/sessions`, { headers: authHeaders });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = await res.json();
   return data.sessions;
@@ -12,7 +18,7 @@ export async function fetchSessions(): Promise<SessionInfo[]> {
 export async function connectSession(sessionId: string): Promise<string> {
   const res = await fetch(`${API_BASE}/api/connect`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: authHeaders,
     body: JSON.stringify({ sessionId }),
   });
   if (!res.ok) {
@@ -30,7 +36,7 @@ export async function sendMessage(
 ): Promise<void> {
   const res = await fetch(`${API_BASE}/api/sessions/${sessionId}/message`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: authHeaders,
     body: JSON.stringify({ content, connectionId }),
   });
   if (!res.ok) {
@@ -46,20 +52,22 @@ export async function sendControl(
 ): Promise<void> {
   await fetch(`${API_BASE}/api/sessions/${sessionId}/control`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: authHeaders,
     body: JSON.stringify({ type: controlType, connectionId }),
   });
 }
 
 export async function disconnectSession(connectionId: string): Promise<void> {
-  await fetch(`${API_BASE}/api/connections/${connectionId}`, { method: "DELETE" }).catch(() => {});
+  await fetch(`${API_BASE}/api/connections/${connectionId}`, { method: "DELETE", headers: authHeaders }).catch(() => {});
 }
 
 export function subscribeToEvents(
   sessionId: string,
   connectionId: string
 ): EventSource {
+  const params = new URLSearchParams({ connectionId });
+  if (SECRET) params.set('secret', SECRET);
   return new EventSource(
-    `${API_BASE}/api/sessions/${sessionId}/events?connectionId=${connectionId}`
+    `${API_BASE}/api/sessions/${sessionId}/events?${params}`
   );
 }

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,10 @@
 # Anthropic OAuth token (run: claude oauth-token)
+# Not needed if ANTHROPIC_REFRESH_TOKEN is set — server will auto-refresh
 ANTHROPIC_TOKEN=
+
+# Anthropic OAuth refresh token (long-lived, auto-refreshes the access token)
+# Extract from Keychain: security find-generic-password -s "Claude Code-credentials" -w | python3 -c "import sys,json; print(json.loads(sys.stdin.read())['claudeAiOauth']['refreshToken'])"
+ANTHROPIC_REFRESH_TOKEN=
 
 # Anthropic organization UUID (optional)
 # Run: claude auth status

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,5 @@
-# Anthropic OAuth token (run: claude oauth-token)
-# Not needed if ANTHROPIC_REFRESH_TOKEN is set — server will auto-refresh
+# Anthropic OAuth access token (not needed if ANTHROPIC_REFRESH_TOKEN is set)
+# Short-lived (~10 hours). Prefer using the refresh token for deployments.
 ANTHROPIC_TOKEN=
 
 # Anthropic OAuth refresh token (long-lived, auto-refreshes the access token)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -21,6 +21,7 @@ app.use((_req, res, next) => {
 app.use("/api", (req, res, next) => {
   if (!WATCHCODE_SECRET) return next(); // no secret configured = open (local dev)
   if (req.headers["x-watchcode-secret"] === WATCHCODE_SECRET) return next();
+  if (req.query.secret === WATCHCODE_SECRET) return next(); // EventSource can't send headers
   res.status(401).json({ error: "Unauthorized" });
 });
 
@@ -30,11 +31,75 @@ const connections = new Map<string, Connection>();
 // --- Credentials: env vars (production) or Keychain (local dev) ---
 let localToken: string | null = process.env.ANTHROPIC_TOKEN || null;
 let localOrgUuid: string | null = process.env.ANTHROPIC_ORG_UUID || null;
+let refreshToken: string | null = process.env.ANTHROPIC_REFRESH_TOKEN || null;
+let tokenExpiresAt: number | null = null; // ms timestamp
+
+const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const OAUTH_SCOPES = "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000; // refresh 5 min before expiry
+
+async function refreshAccessToken(): Promise<boolean> {
+  if (!refreshToken) return false;
+
+  console.log("[auth] Refreshing OAuth access token...");
+  try {
+    const res = await fetch("https://platform.claude.com/v1/oauth/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: OAUTH_CLIENT_ID,
+        scope: OAUTH_SCOPES,
+      }),
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      console.error(`[auth] Refresh failed (${res.status}): ${body}`);
+      return false;
+    }
+
+    const data = await res.json();
+    localToken = data.access_token;
+    if (data.refresh_token) refreshToken = data.refresh_token;
+    tokenExpiresAt = Date.now() + data.expires_in * 1000;
+    localOrgUuid = data.organization?.uuid || localOrgUuid;
+
+    console.log(`[auth] Token refreshed, expires in ${data.expires_in}s`);
+    return true;
+  } catch (err: any) {
+    console.error(`[auth] Refresh error: ${err.message}`);
+    return false;
+  }
+}
+
+async function ensureFreshToken(): Promise<void> {
+  if (!refreshToken || !tokenExpiresAt) return;
+  if (Date.now() < tokenExpiresAt - TOKEN_REFRESH_BUFFER_MS) return;
+  await refreshAccessToken();
+}
 
 function loadLocalCredentials() {
-  // If env vars are set, skip Keychain entirely
+  // If refresh token is available, do an initial refresh to get a valid access token
+  if (refreshToken) {
+    console.log("[auth] Refresh token configured — will refresh on startup");
+    if (localToken) {
+      // Treat the provided access token as potentially expired; set a short expiry to trigger refresh
+      tokenExpiresAt = Date.now() + 60_000;
+      console.log("[auth] Access token loaded from env (will refresh soon)");
+    } else {
+      // No access token at all, force immediate refresh
+      tokenExpiresAt = 0;
+    }
+    if (localOrgUuid) console.log(`[auth] Org UUID from env: ${localOrgUuid}`);
+    return;
+  }
+
+  // If only access token is set (no refresh), use it as-is
   if (localToken) {
-    console.log("[auth] Token loaded from ANTHROPIC_TOKEN env var");
+    console.log("[auth] Token loaded from ANTHROPIC_TOKEN env var (no refresh token — will expire)");
     if (localOrgUuid) console.log(`[auth] Org UUID from env: ${localOrgUuid}`);
     return;
   }
@@ -47,7 +112,11 @@ function loadLocalCredentials() {
     ).trim();
     const creds = JSON.parse(raw);
     localToken = creds.claudeAiOauth?.accessToken || null;
+    refreshToken = creds.claudeAiOauth?.refreshToken || null;
+    const expiresAt = creds.claudeAiOauth?.expiresAt;
+    if (expiresAt) tokenExpiresAt = Number(expiresAt);
     if (localToken) console.log("[auth] OAuth token loaded from Keychain");
+    if (refreshToken) console.log("[auth] Refresh token loaded from Keychain");
   } catch {
     console.log("[auth] Could not read Keychain — use Authorization header or set ANTHROPIC_TOKEN");
   }
@@ -63,9 +132,10 @@ function loadLocalCredentials() {
   }
 }
 
-function getToken(req: express.Request): string | null {
+async function getToken(req: express.Request): Promise<string | null> {
   const auth = req.headers.authorization;
   if (auth?.startsWith("Bearer ")) return auth.slice(7);
+  await ensureFreshToken();
   return localToken;
 }
 
@@ -77,7 +147,7 @@ function getOrgUuid(req: express.Request): string {
 
 // List available sessions
 app.get("/api/sessions", async (req, res) => {
-  const token = getToken(req);
+  const token = await getToken(req);
   const orgUuid = getOrgUuid(req);
 
   if (!token) {
@@ -96,7 +166,7 @@ app.get("/api/sessions", async (req, res) => {
 // Connect to a Remote Control session
 app.post("/api/connect", async (req, res) => {
   const { sessionId } = req.body;
-  const token = getToken(req);
+  const token = await getToken(req);
   const orgUuid = getOrgUuid(req);
 
   if (!sessionId) {
@@ -307,6 +377,14 @@ app.get("/api/status", (_req, res) => {
 
 // --- Start ---
 loadLocalCredentials();
-app.listen(PORT, () => {
-  console.log(`\n[relay] WatchCode relay server running on http://localhost:${PORT}\n`);
-});
+
+(async () => {
+  // If we have a refresh token, do an initial refresh to get a valid access token
+  if (refreshToken && (!localToken || (tokenExpiresAt && Date.now() >= tokenExpiresAt - TOKEN_REFRESH_BUFFER_MS))) {
+    await refreshAccessToken();
+  }
+
+  app.listen(PORT, () => {
+    console.log(`\n[relay] WatchCode relay server running on http://localhost:${PORT}\n`);
+  });
+})();


### PR DESCRIPTION
## Summary
- **Server:** Add automatic OAuth token refresh using `ANTHROPIC_REFRESH_TOKEN` env var so deployed servers stay authenticated indefinitely (tokens from `claude setup-token` only have `user:inference` scope and can't access the sessions API)
- **Client:** Send `x-watchcode-secret` header on all API requests and pass secret as query param for SSE (EventSource doesn't support custom headers)
- **Docs:** Update README deployment table and setup instructions with refresh token guidance

## Test plan
- [ ] Set `ANTHROPIC_REFRESH_TOKEN` on Railway and verify server auto-refreshes on startup
- [ ] Verify `/api/sessions` returns sessions without needing `ANTHROPIC_TOKEN`
- [ ] Verify client connects with `VITE_WATCHCODE_SECRET` set in `.env`
- [ ] Verify SSE stream works with secret passed as query param
- [ ] Verify local dev still works (Keychain fallback loads both tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)